### PR TITLE
Fixes #17 :Fix avatartags serialization issue by stripping tags

### DIFF
--- a/dependency-reduced-pom.xml
+++ b/dependency-reduced-pom.xml
@@ -4,7 +4,7 @@
   <groupId>net.sybyline</groupId>
   <artifactId>scarlet</artifactId>
   <name>Scarlet</name>
-  <version>0.4.13</version><!--scarlet-version-->
+  <version>0.4.13</version>
   <build>
     <plugins>
       <plugin>
@@ -63,11 +63,11 @@
     </repository>
   </repositories>
   <properties>
-    <vrchatapi.version>1.20.4</vrchatapi.version>
-    <JDA.version>6.1.0</JDA.version>
     <selenium.version>4.31.0</selenium.version>
     <nanohttpd.version>2.3.2-SNAPSHOT</nanohttpd.version>
+    <JDA.version>6.1.0</JDA.version>
     <jcef.version>132.3.1</jcef.version>
     <jna.version>4.4.0</jna.version>
+    <vrchatapi.version>1.20.4</vrchatapi.version>
   </properties>
 </project>

--- a/src/main/java/net/sybyline/scarlet/ScarletVRChat.java
+++ b/src/main/java/net/sybyline/scarlet/ScarletVRChat.java
@@ -123,7 +123,9 @@ public class ScarletVRChat implements Closeable
                             return null;
                         }
                         JsonElement je = prevJE.read(in);
-                        
+
+                        // TODO: update dependencies to support the api change
+
                         // Fix for VRChat API change: currentAvatarTags is now an array instead of string
                         // Strip it from presence object to avoid deserialization errors
                         if (je.isJsonObject()) {
@@ -135,6 +137,7 @@ public class ScarletVRChat implements Closeable
                                 }
                             }
                         }
+                        // TODO: update dependencies to support the api change
                         
                         T value;
                         try {

--- a/src/main/java/net/sybyline/scarlet/ScarletVRChat.java
+++ b/src/main/java/net/sybyline/scarlet/ScarletVRChat.java
@@ -123,6 +123,19 @@ public class ScarletVRChat implements Closeable
                             return null;
                         }
                         JsonElement je = prevJE.read(in);
+                        
+                        // Fix for VRChat API change: currentAvatarTags is now an array instead of string
+                        // Strip it from presence object to avoid deserialization errors
+                        if (je.isJsonObject()) {
+                            JsonObject obj = je.getAsJsonObject();
+                            if (obj.has("presence") && obj.get("presence").isJsonObject()) {
+                                JsonObject presence = obj.getAsJsonObject("presence");
+                                if (presence.has("currentAvatarTags")) {
+                                    presence.remove("currentAvatarTags");
+                                }
+                            }
+                        }
+                        
                         T value;
                         try {
                             value = prevTA.fromJsonTree(je);


### PR DESCRIPTION
This is a simple workaround to strip avatar tags from the loading process till the VRChat api can be fixed/updated to match.

This closes Issue #17 